### PR TITLE
corp-downloading function is added

### DIFF
--- a/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/js/corpus_downloader.js
+++ b/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/js/corpus_downloader.js
@@ -1,0 +1,7 @@
+function corpDownloader(uri,filename) { 
+    var link = document.createElement("a");
+    link.download = name;
+    link.href = uri;
+    link.click();
+    alert("Press Ctrl+S (Win/Linux) or Cmd+S (Mac OS) to download the file :)");
+}

--- a/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/s4_end.html
+++ b/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/s4_end.html
@@ -18,7 +18,7 @@
 
 </head>
 
-<body onload="corpDownloader('https://github.com/nstsj/hseling-repo-cross-lingual-morph-analysis/blob/master/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/to_download.txt','to_download.txt')">
+<body onload="corpDownloader('hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/to_download.txt','to_download.txt')">
 <div class="text-center" id="nav_bar">
     <nav class="navbar nav-pills bg-dark">
         <div class="col-7">

--- a/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/s4_end.html
+++ b/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/s4_end.html
@@ -14,9 +14,11 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/all.css">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/v4-shims.css">
     <link rel="stylesheet" href="css/styles.css">
+    <script src="js/corpus_downloader.js"></script>
+
 </head>
 
-<body>
+<body onload="corpDownloader('https://github.com/nstsj/hseling-repo-cross-lingual-morph-analysis/blob/master/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/to_download.txt','to_download.txt')">
 <div class="text-center" id="nav_bar">
     <nav class="navbar nav-pills bg-dark">
         <div class="col-7">

--- a/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/to_download.txt
+++ b/hseling_web_cross_lingual_morph_analysis/src/web/static/frontend/to_download.txt
@@ -1,0 +1,2 @@
+hi i'm final processed corpus for our user
+


### PR DESCRIPTION
A new function (for user to download their final processed corpus) is added, all the necessary files are added to the folders respectively. 

PS: as for now we're able to download a test-file that simulates a real corpus. We'll need to further connect backend to be able to get to real corpus (but this goes beyond this PR) 

